### PR TITLE
Flatten note namespace

### DIFF
--- a/src/note.cpp
+++ b/src/note.cpp
@@ -20,9 +20,7 @@ int get12BitNote(byte note, byte octave) {
     return (int) round((float) (note * octave) * 34.1333333);
 }
 
-namespace key {
-
-void getMajor(byte root, byte* key) {
+void getKeyMajor(byte root, byte* key) {
     key[0] = root;
     key[1] = ascend(root, 2);
     key[2] = ascend(root, 4);
@@ -33,7 +31,7 @@ void getMajor(byte root, byte* key) {
     key[7] = ascend(root, 12);
 }
 
-void getMinor(byte root, byte* key) {
+void getKeyMinor(byte root, byte* key) {
     key[0] = root;
     key[1] = ascend(root, 2);
     key[2] = ascend(root, 3);
@@ -43,12 +41,7 @@ void getMinor(byte root, byte* key) {
     key[6] = ascend(root, 10);
     key[7] = ascend(root, 12);
 }
-
-} // namespace key
-
-namespace chord {
-
-void get(byte rootIndex, byte* key, byte* chord) {
+void getChord(byte rootIndex, byte* key, byte* chord) {
     chord[0] = key[rootIndex]; 
     chord[1] = key[getNoteIndex(rootIndex + 2)];
     chord[2] = key[getNoteIndex(rootIndex + 4)];
@@ -59,11 +52,11 @@ void getProgression(byte* key, byte** progression) {
     byte current = 0;
     byte size = 0;
     do {
-        get(current, key, progression[++size]);
+        getChord(current, key, progression[++size]);
         current = getNextIndex(current);
     } while (current != 0 && size < MAX_CHORD_PROGRESSION_LENGTH);
     if (current != 0 && (current == 2 || current == 5))
-        get(3, key, progression[++size]);
+        getChord(3, key, progression[++size]);
     progression[0][0] = size;
 }
 
@@ -95,7 +88,5 @@ byte getNoteIndex(byte index) {
         return index;
     return index - 8;
 }
-
-} // namespace chord
 
 } // namespace note

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -2,14 +2,14 @@
 
 namespace note {
 
-byte ascend(byte note, byte semitones) {
+byte getNoteAscending(byte note, byte semitones) {
     byte newNote = note + semitones;
     if (newNote < 12)
         return newNote;
     return newNote - 12;
 }
 
-byte descend(byte note, byte semitones) {
+byte getNoteDescending(byte note, byte semitones) {
     byte newNote = (note + 12) - semitones;
     if (newNote < 12)
         return newNote;
@@ -22,24 +22,24 @@ int get12BitNote(byte note, byte octave) {
 
 void getKeyMajor(byte root, byte* key) {
     key[0] = root;
-    key[1] = ascend(root, 2);
-    key[2] = ascend(root, 4);
-    key[3] = ascend(root, 5);
-    key[4] = ascend(root, 7);
-    key[5] = ascend(root, 9);
-    key[6] = ascend(root, 11);
-    key[7] = ascend(root, 12);
+    key[1] = getNoteAscending(root, 2);
+    key[2] = getNoteAscending(root, 4);
+    key[3] = getNoteAscending(root, 5);
+    key[4] = getNoteAscending(root, 7);
+    key[5] = getNoteAscending(root, 9);
+    key[6] = getNoteAscending(root, 11);
+    key[7] = getNoteAscending(root, 12);
 }
 
 void getKeyMinor(byte root, byte* key) {
     key[0] = root;
-    key[1] = ascend(root, 2);
-    key[2] = ascend(root, 3);
-    key[3] = ascend(root, 5);
-    key[4] = ascend(root, 7);
-    key[5] = ascend(root, 8);
-    key[6] = ascend(root, 10);
-    key[7] = ascend(root, 12);
+    key[1] = getNoteAscending(root, 2);
+    key[2] = getNoteAscending(root, 3);
+    key[3] = getNoteAscending(root, 5);
+    key[4] = getNoteAscending(root, 7);
+    key[5] = getNoteAscending(root, 8);
+    key[6] = getNoteAscending(root, 10);
+    key[7] = getNoteAscending(root, 12);
 }
 void getChord(byte rootIndex, byte* key, byte* chord) {
     chord[0] = key[rootIndex]; 

--- a/src/note.h
+++ b/src/note.h
@@ -40,8 +40,6 @@ byte descend(byte note, byte semitones);
  * @return 12 bir representation of the note.
  */
 int get12BitNote(byte note, byte octave);
-
-namespace key {
 /**
  * Assign the major key for the provided root note to the provided
  * array pointer.
@@ -49,7 +47,7 @@ namespace key {
  * @param root root note for key.
  * @param key array pointer to copy key notes to.
  */
-void getMajor(byte root, byte* key);
+void getKeyMajor(byte root, byte* key);
 /**
  * Assign the minor key for the provided root note to the provided
  * array pointer.
@@ -57,10 +55,7 @@ void getMajor(byte root, byte* key);
  * @param root root note for key.
  * @param key array pointer to copy key notes to.
  */
-void getMinor(byte root, byte* key);
-} // namespace key
-
-namespace chord {
+void getKeyMinor(byte root, byte* key);
 /**
  * Assign the chord at the root index in a key to the array 
  * pointer.
@@ -69,7 +64,7 @@ namespace chord {
  * @param key pointer to array containing the key notes.
  * @param chord pointer to array to assign chord notes to.
  */
-void get(byte rootIndex, byte* key, byte* chord);
+void getChord(byte rootIndex, byte* key, byte* chord);
 /**
  * Get random chord progression between 2 and 5 chords long.
  * 
@@ -79,6 +74,5 @@ void get(byte rootIndex, byte* key, byte* chord);
  */
 void getProgression(byte* key, byte** progression);
 } // namespace chord
-} // namespace note
 
 #endif /* NOTE_H */


### PR DESCRIPTION
- Flattened the note namespace to reflect best practices.
- Renamed function names to not imply design using namespaces and remove ambiguities.